### PR TITLE
DM-13904: Specify EUPS-provided Eigen include directory.

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -1,6 +1,6 @@
 build()
 {
-	(mkdir build && cd build && cmake -DNDARRAY_SWIG=OFF -DNDARRAY_PYBIND11=ON -DFFTW_ROOT=$FFTW_DIR -DBOOST_ROOT=$BOOST_DIR -DCMAKE_INSTALL_PREFIX=$PREFIX .. && make && make test)
+	(mkdir build && cd build && cmake -DNDARRAY_SWIG=OFF -DNDARRAY_PYBIND11=ON -DFFTW_ROOT=$FFTW_DIR -DBOOST_ROOT=$BOOST_DIR -DEIGEN3_INCLUDE_DIR=$EIGEN_DIR/include -DCMAKE_INSTALL_PREFIX=$PREFIX .. && make && make test)
 }
 
 install()


### PR DESCRIPTION
This ensures we don't pick up a system Eigen installation.