### PR TITLE
DM-14834: Use pybind11's native Eigen wrapping instead of ndarray EigenView

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -1,6 +1,6 @@
 build()
 {
-	(mkdir build && cd build && cmake -DNDARRAY_PYBIND11=ON -DNDARRAY_EIGENVIEW=ON -DFFTW_ROOT=$FFTW_DIR -DBOOST_ROOT=$BOOST_DIR -DEIGEN3_INCLUDE_DIR=$EIGEN_DIR/include -DCMAKE_INSTALL_PREFIX=$PREFIX .. && make && make test)
+	(mkdir build && cd build && cmake -DNDARRAY_PYBIND11=ON -DFFTW_ROOT=$FFTW_DIR -DBOOST_ROOT=$BOOST_DIR -DEIGEN3_INCLUDE_DIR=$EIGEN_DIR/include -DCMAKE_INSTALL_PREFIX=$PREFIX .. && make && make test)
 }
 
 install()


### PR DESCRIPTION
build without EigenView and with standard pybind11 Eigen support