### PR TITLE
DM-22817: Disable cmake cleverness with boost > v1.70

### DIFF
--- a/ups/eupspkg.cfg.sh
+++ b/ups/eupspkg.cfg.sh
@@ -1,6 +1,6 @@
 build()
 {
-	(mkdir build && cd build && cmake -DNDARRAY_PYBIND11=ON -DFFTW_ROOT=$FFTW_DIR -DBOOST_ROOT=$BOOST_DIR -DEIGEN3_INCLUDE_DIR=$EIGEN_DIR/include -DCMAKE_INSTALL_PREFIX=$PREFIX .. && make && make test)
+	(mkdir build && cd build && cmake -DBoost_NO_BOOST_CMAKE=ON -DNDARRAY_PYBIND11=ON -DFFTW_ROOT=$FFTW_DIR -DBOOST_ROOT=$BOOST_DIR -DEIGEN3_INCLUDE_DIR=$EIGEN_DIR/include -DCMAKE_INSTALL_PREFIX=$PREFIX .. && make && make test)
 }
 
 install()


### PR DESCRIPTION
We do not want to pick up the conda boost.